### PR TITLE
feat: カスタムシンボル機能 (#9)

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -76,7 +76,7 @@ export default function App() {
     socket.emit('room:join', code, playerName, (res) => {
       if (!res.ok) showError(res.error || '部屋への参加に失敗しました');
     });
-  }, []);
+  }, [showError]);
 
   const handleBackToLobby = useCallback(() => {
     socket.emit('game:backToLobby');
@@ -143,7 +143,7 @@ export default function App() {
         <Countdown count={countdownNum} />
       )}
       {page === 'game' && gameState && (
-        <Game gameState={gameState} myId={socket.id || ''} />
+        <Game gameState={gameState} myId={socket.id || ''} customSymbols={room?.customSymbols} />
       )}
       {page === 'result' && (
         <Result

--- a/client/src/components/Card.tsx
+++ b/client/src/components/Card.tsx
@@ -7,6 +7,7 @@ interface Props {
   onSymbolClick?: (symbolId: number) => void;
   disabled?: boolean;
   size?: number;
+  customSymbols?: Record<number, string>;
 }
 
 /** カード上のシンボル配置を計算 (8個を円形に配置) */
@@ -39,7 +40,7 @@ function getRotation(symbolId: number, cardId: number): number {
   return ((symbolId * 137 + cardId * 31) % 360);
 }
 
-export default function Card({ card, onSymbolClick, disabled, size }: Props) {
+export default function Card({ card, onSymbolClick, disabled, size, customSymbols }: Props) {
   const defaultSize = Math.min(280, typeof window !== 'undefined' ? window.innerWidth * 0.42 : 280);
   const actualCardSize = size ?? defaultSize;
   const layout = useMemo(() => getSymbolLayout(card.symbols.length), [card.symbols.length]);
@@ -64,8 +65,9 @@ export default function Card({ card, onSymbolClick, disabled, size }: Props) {
         const pos = layout[index];
         if (!pos) return null;
 
+        const customDataUrl = customSymbols?.[symbolId];
         const SymbolComponent = SYMBOLS[symbolId];
-        if (!SymbolComponent) return null;
+        if (!customDataUrl && !SymbolComponent) return null;
 
         const rotation = getRotation(symbolId, card.id);
         const actualScale = pos.scale;
@@ -103,7 +105,20 @@ export default function Card({ card, onSymbolClick, disabled, size }: Props) {
               e.currentTarget.style.transform = `translate(-50%, -50%) rotate(${rotation}deg)`;
             }}
           >
-            <SymbolComponent size={actualSize} />
+            {customDataUrl ? (
+              <img
+                src={customDataUrl}
+                alt={SYMBOL_NAMES[symbolId]}
+                style={{
+                  width: actualSize,
+                  height: actualSize,
+                  objectFit: 'contain',
+                  pointerEvents: 'none',
+                }}
+              />
+            ) : (
+              <SymbolComponent size={actualSize} />
+            )}
           </button>
         );
       })}

--- a/client/src/pages/Game.tsx
+++ b/client/src/pages/Game.tsx
@@ -6,6 +6,7 @@ import CardView from '../components/Card';
 interface Props {
   gameState: GameState;
   myId: string;
+  customSymbols?: Record<number, string>;
 }
 
 function formatTime(ms: number): string {
@@ -15,7 +16,7 @@ function formatTime(ms: number): string {
   return `${min}:${sec.toString().padStart(2, '0')}`;
 }
 
-export default function Game({ gameState, myId }: Props) {
+export default function Game({ gameState, myId, customSymbols }: Props) {
   const [lastMatch, setLastMatch] = useState<MatchResult | null>(null);
   const [cooldown, setCooldown] = useState(false);
   const [elapsed, setElapsed] = useState(0);
@@ -167,6 +168,7 @@ export default function Game({ gameState, myId }: Props) {
               card={gameState.centerCard}
               onSymbolClick={handleSymbolClick}
               disabled={cooldown}
+              customSymbols={customSymbols}
             />
           )}
         </div>
@@ -181,6 +183,7 @@ export default function Game({ gameState, myId }: Props) {
               card={gameState.myCard}
               onSymbolClick={handleSymbolClick}
               disabled={cooldown}
+              customSymbols={customSymbols}
             />
           ) : (
             <div style={{

--- a/client/src/pages/Lobby.tsx
+++ b/client/src/pages/Lobby.tsx
@@ -1,13 +1,16 @@
-import { useState } from 'react';
+import { useState, useRef, useCallback } from 'react';
 import { socket } from '../socket';
 import type { RoomInfo, GameMode, GameSettings } from 'dokoda-shared';
 import {
   MAX_PENALTY_COOLDOWN,
   TOTAL_CARDS,
+  TOTAL_SYMBOLS,
+  MAX_CUSTOM_SYMBOL_SIZE,
   MIN_TIME_LIMIT_SEC,
   MAX_TIME_LIMIT_SEC,
   getMinCards,
 } from 'dokoda-shared';
+import { SYMBOLS, SYMBOL_NAMES } from '../symbols';
 
 interface Props {
   room: RoomInfo;
@@ -104,6 +107,199 @@ function RoomCode({ code }: { code: string }) {
           )}
         </button>
       </div>
+    </div>
+  );
+}
+
+function SymbolCustomizer({ customSymbols, isHost }: { customSymbols: Record<number, string>; isHost: boolean }) {
+  const [expanded, setExpanded] = useState(false);
+  const [uploading, setUploading] = useState<number | null>(null);
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  const selectedSymbolRef = useRef<number>(0);
+
+  const customCount = Object.keys(customSymbols).length;
+
+  const handleFileSelect = useCallback((symbolId: number) => {
+    selectedSymbolRef.current = symbolId;
+    fileInputRef.current?.click();
+  }, []);
+
+  const handleFileChange = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    e.target.value = '';
+
+    if (!file.type.startsWith('image/')) return;
+
+    const reader = new FileReader();
+    reader.onload = () => {
+      const dataUrl = reader.result as string;
+      if (dataUrl.length > MAX_CUSTOM_SYMBOL_SIZE) {
+        alert('画像サイズが大きすぎます（200KB以下にしてください）');
+        return;
+      }
+      const symbolId = selectedSymbolRef.current;
+      setUploading(symbolId);
+      socket.emit('room:uploadSymbol', symbolId, dataUrl, (res) => {
+        setUploading(null);
+        if (!res.ok) alert(res.error || 'アップロードに失敗しました');
+      });
+    };
+    reader.readAsDataURL(file);
+  }, []);
+
+  const handleDelete = useCallback((symbolId: number) => {
+    socket.emit('room:deleteSymbol', symbolId);
+  }, []);
+
+  const handleResetAll = useCallback(() => {
+    socket.emit('room:resetSymbols');
+  }, []);
+
+  return (
+    <div style={{
+      background: 'var(--bg-secondary)',
+      borderRadius: 16,
+      padding: 18,
+      width: '100%',
+      maxWidth: 400,
+    }}>
+      <button
+        onClick={() => setExpanded(!expanded)}
+        style={{
+          background: 'transparent',
+          border: 'none',
+          color: 'var(--text-secondary)',
+          fontSize: 13,
+          cursor: 'pointer',
+          display: 'flex',
+          alignItems: 'center',
+          gap: 6,
+          width: '100%',
+          padding: 0,
+        }}
+      >
+        <span style={{ transform: expanded ? 'rotate(90deg)' : 'none', transition: 'transform 0.2s', fontSize: 10 }}>
+          ▶
+        </span>
+        シンボルカスタマイズ
+        {customCount > 0 && (
+          <span style={{
+            background: 'var(--accent)',
+            color: 'white',
+            fontSize: 10,
+            padding: '1px 5px',
+            borderRadius: 4,
+            fontWeight: 700,
+          }}>
+            {customCount}
+          </span>
+        )}
+        {!isHost && '（ホストのみ）'}
+      </button>
+
+      {expanded && (
+        <div style={{ marginTop: 12 }}>
+          <input
+            ref={fileInputRef}
+            type="file"
+            accept="image/png,image/jpeg,image/svg+xml,image/webp"
+            style={{ display: 'none' }}
+            onChange={handleFileChange}
+          />
+
+          {isHost && customCount > 0 && (
+            <button
+              onClick={handleResetAll}
+              style={{
+                background: 'transparent',
+                border: '1px solid var(--accent)',
+                color: 'var(--accent)',
+                fontSize: 11,
+                padding: '4px 10px',
+                borderRadius: 6,
+                cursor: 'pointer',
+                marginBottom: 10,
+              }}
+            >
+              全てリセット
+            </button>
+          )}
+
+          <div style={{
+            display: 'grid',
+            gridTemplateColumns: 'repeat(auto-fill, minmax(48px, 1fr))',
+            gap: 6,
+            maxHeight: 240,
+            overflowY: 'auto',
+          }}>
+            {Array.from({ length: TOTAL_SYMBOLS }, (_, i) => {
+              const hasCustom = i in customSymbols;
+              const isUploading = uploading === i;
+              const SymbolComponent = SYMBOLS[i];
+
+              return (
+                <div
+                  key={i}
+                  style={{
+                    width: 48,
+                    height: 48,
+                    borderRadius: 8,
+                    border: hasCustom ? '2px solid var(--success)' : '2px solid rgba(255,255,255,0.1)',
+                    background: 'var(--bg-primary)',
+                    display: 'flex',
+                    alignItems: 'center',
+                    justifyContent: 'center',
+                    position: 'relative',
+                    cursor: isHost ? 'pointer' : 'default',
+                    opacity: isUploading ? 0.5 : 1,
+                  }}
+                  onClick={() => isHost && handleFileSelect(i)}
+                  title={`${SYMBOL_NAMES[i]}${hasCustom ? '（カスタム）' : ''}`}
+                >
+                  {hasCustom ? (
+                    <img
+                      src={customSymbols[i]}
+                      alt={SYMBOL_NAMES[i]}
+                      style={{ width: 32, height: 32, objectFit: 'contain' }}
+                    />
+                  ) : (
+                    SymbolComponent && <SymbolComponent size={32} />
+                  )}
+                  {hasCustom && isHost && (
+                    <button
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        handleDelete(i);
+                      }}
+                      style={{
+                        position: 'absolute',
+                        top: -4,
+                        right: -4,
+                        width: 16,
+                        height: 16,
+                        borderRadius: '50%',
+                        background: 'var(--accent)',
+                        color: 'white',
+                        border: 'none',
+                        fontSize: 10,
+                        lineHeight: 1,
+                        cursor: 'pointer',
+                        display: 'flex',
+                        alignItems: 'center',
+                        justifyContent: 'center',
+                        padding: 0,
+                      }}
+                    >
+                      ✕
+                    </button>
+                  )}
+                </div>
+              );
+            })}
+          </div>
+        </div>
+      )}
     </div>
   );
 }
@@ -289,6 +485,9 @@ export default function Lobby({ room, myId }: Props) {
           </div>
         )}
       </div>
+
+      {/* シンボルカスタマイズ */}
+      <SymbolCustomizer customSymbols={room.customSymbols} isHost={isHost} />
 
       {/* 開始ボタン */}
       {isHost ? (

--- a/server/src/__tests__/room.test.ts
+++ b/server/src/__tests__/room.test.ts
@@ -246,6 +246,97 @@ describe('RoomManager', () => {
     });
   });
 
+  describe('customSymbols', () => {
+    const VALID_DATA_URL = 'data:image/png;base64,iVBOR';
+
+    it('room starts with empty customSymbols', () => {
+      const socket = createMockSocket('host');
+      const room = manager.createRoom(socket, 'Host');
+      expect(room.customSymbols.size).toBe(0);
+    });
+
+    it('host can upload a custom symbol', () => {
+      const socket = createMockSocket('host');
+      const room = manager.createRoom(socket, 'Host');
+
+      const result = manager.uploadSymbol(room, 'host', 0, VALID_DATA_URL);
+      expect(result.ok).toBe(true);
+      expect(room.customSymbols.get(0)).toBe(VALID_DATA_URL);
+    });
+
+    it('non-host cannot upload', () => {
+      const host = createMockSocket('host');
+      const room = manager.createRoom(host, 'Host');
+      manager.joinRoom(createMockSocket('joiner'), room.code, 'Joiner');
+
+      const result = manager.uploadSymbol(room, 'joiner', 0, VALID_DATA_URL);
+      expect(result.ok).toBe(false);
+      expect(result.error).toContain('ホスト');
+    });
+
+    it('rejects upload during non-lobby phase', () => {
+      const socket = createMockSocket('host');
+      const room = manager.createRoom(socket, 'Host');
+      room.phase = 'playing';
+
+      const result = manager.uploadSymbol(room, 'host', 0, VALID_DATA_URL);
+      expect(result.ok).toBe(false);
+    });
+
+    it('rejects invalid symbol ID', () => {
+      const socket = createMockSocket('host');
+      const room = manager.createRoom(socket, 'Host');
+
+      expect(manager.uploadSymbol(room, 'host', -1, VALID_DATA_URL).ok).toBe(false);
+      expect(manager.uploadSymbol(room, 'host', 57, VALID_DATA_URL).ok).toBe(false);
+      expect(manager.uploadSymbol(room, 'host', 1.5, VALID_DATA_URL).ok).toBe(false);
+    });
+
+    it('rejects non-image data URL', () => {
+      const socket = createMockSocket('host');
+      const room = manager.createRoom(socket, 'Host');
+
+      expect(manager.uploadSymbol(room, 'host', 0, 'not-a-data-url').ok).toBe(false);
+      expect(manager.uploadSymbol(room, 'host', 0, 'data:text/plain;base64,abc').ok).toBe(false);
+    });
+
+    it('rejects oversized data URL', () => {
+      const socket = createMockSocket('host');
+      const room = manager.createRoom(socket, 'Host');
+
+      const big = 'data:image/png;base64,' + 'A'.repeat(300 * 1024);
+      expect(manager.uploadSymbol(room, 'host', 0, big).ok).toBe(false);
+    });
+
+    it('host can delete a custom symbol', () => {
+      const socket = createMockSocket('host');
+      const room = manager.createRoom(socket, 'Host');
+      manager.uploadSymbol(room, 'host', 5, VALID_DATA_URL);
+
+      expect(manager.deleteSymbol(room, 'host', 5)).toBe(true);
+      expect(room.customSymbols.has(5)).toBe(false);
+    });
+
+    it('host can reset all custom symbols', () => {
+      const socket = createMockSocket('host');
+      const room = manager.createRoom(socket, 'Host');
+      manager.uploadSymbol(room, 'host', 0, VALID_DATA_URL);
+      manager.uploadSymbol(room, 'host', 1, VALID_DATA_URL);
+
+      expect(manager.resetSymbols(room, 'host')).toBe(true);
+      expect(room.customSymbols.size).toBe(0);
+    });
+
+    it('getRoomInfo includes customSymbols as plain object', () => {
+      const socket = createMockSocket('host');
+      const room = manager.createRoom(socket, 'Host');
+      manager.uploadSymbol(room, 'host', 3, VALID_DATA_URL);
+
+      const info = manager.getRoomInfo(room);
+      expect(info.customSymbols).toEqual({ 3: VALID_DATA_URL });
+    });
+  });
+
   describe('cleanupInactiveRooms', () => {
     it('removes rooms past timeout', () => {
       const socket = createMockSocket('host');

--- a/server/src/events.ts
+++ b/server/src/events.ts
@@ -137,6 +137,56 @@ export function setupSocketEvents(
       io.to(room.code).emit('room:updated', roomInfo);
     });
 
+    // --- カスタムシンボルアップロード (ホストのみ) ---
+    socket.on('room:uploadSymbol', (symbolId, dataUrl, callback) => {
+      if (!checkRateLimit(socket.id, 'room:uploadSymbol')) {
+        callback({ ok: false, error: 'リクエストが多すぎます' });
+        return;
+      }
+
+      const room = roomManager.getRoomBySocketId(socket.id);
+      if (!room) {
+        callback({ ok: false, error: 'ルームが見つかりません' });
+        return;
+      }
+
+      const result = roomManager.uploadSymbol(room, socket.id, symbolId, dataUrl);
+      if (!result.ok) {
+        callback({ ok: false, error: result.error });
+        return;
+      }
+
+      const roomInfo = roomManager.getRoomInfo(room);
+      io.to(room.code).emit('room:updated', roomInfo);
+      callback({ ok: true });
+    });
+
+    // --- カスタムシンボル削除 (ホストのみ) ---
+    socket.on('room:deleteSymbol', (symbolId) => {
+      if (!checkRateLimit(socket.id, 'room:deleteSymbol')) return;
+
+      const room = roomManager.getRoomBySocketId(socket.id);
+      if (!room) return;
+
+      if (roomManager.deleteSymbol(room, socket.id, symbolId)) {
+        const roomInfo = roomManager.getRoomInfo(room);
+        io.to(room.code).emit('room:updated', roomInfo);
+      }
+    });
+
+    // --- カスタムシンボル一括リセット (ホストのみ) ---
+    socket.on('room:resetSymbols', () => {
+      if (!checkRateLimit(socket.id, 'room:resetSymbols')) return;
+
+      const room = roomManager.getRoomBySocketId(socket.id);
+      if (!room) return;
+
+      if (roomManager.resetSymbols(room, socket.id)) {
+        const roomInfo = roomManager.getRoomInfo(room);
+        io.to(room.code).emit('room:updated', roomInfo);
+      }
+    });
+
     // --- ゲーム開始 ---
     socket.on('game:start', () => {
       if (!checkRateLimit(socket.id, 'game:start')) {

--- a/server/src/rateLimit.ts
+++ b/server/src/rateLimit.ts
@@ -19,6 +19,9 @@ const EVENT_LIMITS: Record<string, RateLimitConfig> = {
   'room:settings': { windowMs: 1000, maxRequests: 5 },
   'game:start': { windowMs: 5000, maxRequests: 3 },
   'game:backToLobby': { windowMs: 3000, maxRequests: 3 },
+  'room:uploadSymbol': { windowMs: 2000, maxRequests: 5 },
+  'room:deleteSymbol': { windowMs: 1000, maxRequests: 5 },
+  'room:resetSymbols': { windowMs: 3000, maxRequests: 3 },
 };
 
 /** デフォルト制限（未定義イベント用） */

--- a/server/src/room.ts
+++ b/server/src/room.ts
@@ -14,6 +14,9 @@ import {
   ROOM_TIMEOUT,
   DEFAULT_PENALTY_COOLDOWN,
   DEFAULT_TIME_LIMIT_SEC,
+  MAX_CUSTOM_SYMBOL_SIZE,
+  MAX_CUSTOM_SYMBOLS,
+  TOTAL_SYMBOLS,
 } from 'dokoda-shared';
 
 /** サーバー側のプレイヤー情報（クライアントに送らない情報を含む） */
@@ -41,6 +44,7 @@ export interface Room {
   finishedAt: number;
   timeAttackTimer: ReturnType<typeof setTimeout> | null;
   countdownTimer: ReturnType<typeof setInterval> | null;
+  customSymbols: Map<number, string>; // symbolId -> base64 data URL
 }
 
 type TypedSocket = Socket<ClientToServerEvents, ServerToClientEvents>;
@@ -86,6 +90,7 @@ export class RoomManager {
       finishedAt: 0,
       timeAttackTimer: null,
       countdownTimer: null,
+      customSymbols: new Map(),
     };
 
     this.rooms.set(code, room);
@@ -233,6 +238,7 @@ export class RoomManager {
       phase: room.phase,
       mode: room.mode,
       settings: room.settings,
+      customSymbols: Object.fromEntries(room.customSymbols),
     };
   }
 
@@ -249,6 +255,53 @@ export class RoomManager {
     }
 
     return count;
+  }
+
+  /** カスタムシンボルをアップロード */
+  uploadSymbol(
+    room: Room,
+    socketId: string,
+    symbolId: number,
+    dataUrl: string
+  ): { ok: boolean; error?: string } {
+    if (room.hostId !== socketId) {
+      return { ok: false, error: 'ホストのみがシンボルを変更できます' };
+    }
+    if (room.phase !== 'lobby') {
+      return { ok: false, error: 'ロビー中のみ変更できます' };
+    }
+    if (!Number.isInteger(symbolId) || symbolId < 0 || symbolId >= TOTAL_SYMBOLS) {
+      return { ok: false, error: '無効なシンボルIDです' };
+    }
+    if (typeof dataUrl !== 'string' || !dataUrl.startsWith('data:image/')) {
+      return { ok: false, error: '無効な画像形式です' };
+    }
+    if (dataUrl.length > MAX_CUSTOM_SYMBOL_SIZE) {
+      return { ok: false, error: '画像サイズが大きすぎます（200KB以下）' };
+    }
+    if (room.customSymbols.size >= MAX_CUSTOM_SYMBOLS && !room.customSymbols.has(symbolId)) {
+      return { ok: false, error: 'カスタムシンボルの上限に達しました' };
+    }
+
+    room.customSymbols.set(symbolId, dataUrl);
+    room.lastActivity = Date.now();
+    return { ok: true };
+  }
+
+  /** カスタムシンボルを削除 */
+  deleteSymbol(room: Room, socketId: string, symbolId: number): boolean {
+    if (room.hostId !== socketId || room.phase !== 'lobby') return false;
+    room.customSymbols.delete(symbolId);
+    room.lastActivity = Date.now();
+    return true;
+  }
+
+  /** 全カスタムシンボルをリセット */
+  resetSymbols(room: Room, socketId: string): boolean {
+    if (room.hostId !== socketId || room.phase !== 'lobby') return false;
+    room.customSymbols.clear();
+    room.lastActivity = Date.now();
+    return true;
   }
 
   /** ランダムなルームコードを生成 */

--- a/shared/src/constants.ts
+++ b/shared/src/constants.ts
@@ -54,3 +54,9 @@ export function getMinCards(mode: string, playerCount: number): number {
 
 /** ルームの自動削除時間 (ms) - 30分 */
 export const ROOM_TIMEOUT = 30 * 60 * 1000;
+
+/** カスタムシンボル: 最大データURLサイズ (バイト) - 約200KB */
+export const MAX_CUSTOM_SYMBOL_SIZE = 200 * 1024;
+
+/** カスタムシンボル: 同時置換上限 */
+export const MAX_CUSTOM_SYMBOLS = 57;

--- a/shared/src/types.ts
+++ b/shared/src/types.ts
@@ -69,6 +69,7 @@ export interface RoomInfo {
   phase: GamePhase;
   mode: GameMode;
   settings: GameSettings;
+  customSymbols: Record<number, string>; // symbolId -> base64 data URL
 }
 
 // --- Socket.io イベント型定義 ---
@@ -88,6 +89,9 @@ export interface ClientToServerEvents {
   'room:create': (playerName: string, callback: (response: { ok: boolean; code?: string; error?: string }) => void) => void;
   'room:join': (code: string, playerName: string, callback: (response: { ok: boolean; error?: string }) => void) => void;
   'room:settings': (settings: GameSettings) => void;
+  'room:uploadSymbol': (symbolId: number, dataUrl: string, callback: (response: { ok: boolean; error?: string }) => void) => void;
+  'room:deleteSymbol': (symbolId: number) => void;
+  'room:resetSymbols': () => void;
   'game:start': () => void;
   'game:claim': (symbolId: number) => void;
   'game:backToLobby': () => void;


### PR DESCRIPTION
## Summary
- ホストがロビーから57種類のシンボルを任意の画像に差し替え可能
- カスタムシンボルはルーム内全プレイヤーに配信され、ゲーム中も反映
- 画像バリデーション（形式: PNG/JPG/SVG/WebP、サイズ: 200KB以下）
- 個別削除・一括リセット対応
- レート制限追加、テスト10件追加（計86件パス）

## Test plan
- [x] shared/server/client 全てビルド成功
- [x] 既存テスト76件 + 新規テスト10件 = 86件パス
- [ ] ホストがシンボルをアップロード → 全プレイヤーに反映されることを確認
- [ ] 非ホストがアップロードできないことを確認
- [ ] ゲーム中にカスタムシンボルが表示されることを確認
- [ ] 一括リセットで全シンボルが元に戻ることを確認

Closes #9

🤖 Generated with [Claude Code](https://claude.com/claude-code)