### PR TITLE
feat: カスタムテーマ機能 (#11)

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -7,10 +7,19 @@ import Game from './pages/Game';
 import Result from './pages/Result';
 import Countdown from './pages/Countdown';
 import Rules from './components/Rules';
+import { useTheme } from './useTheme';
+
+const THEME_ICONS: Record<string, string> = {
+  dark: '🌙',
+  light: '☀️',
+  ocean: '🌊',
+  sakura: '🌸',
+};
 
 type Page = 'home' | 'lobby' | 'countdown' | 'game' | 'result';
 
 export default function App() {
+  const { theme, cycleTheme } = useTheme();
   const [page, setPage] = useState<Page>('home');
   const [room, setRoom] = useState<RoomInfo | null>(null);
   const [gameState, setGameState] = useState<GameState | null>(null);
@@ -103,31 +112,48 @@ export default function App() {
         </div>
       )}
 
-      {/* ルールボタン (常に表示) */}
-      <button
-        onClick={() => setShowRules(true)}
-        style={{
-          position: 'fixed',
-          top: 12,
-          right: 12,
-          zIndex: 900,
-          background: 'var(--bg-secondary)',
-          border: '2px solid var(--accent)',
-          color: 'var(--text-primary)',
-          width: 40,
-          height: 40,
-          borderRadius: '50%',
-          fontSize: 18,
-          fontWeight: 900,
-          cursor: 'pointer',
-          display: 'flex',
-          alignItems: 'center',
-          justifyContent: 'center',
-        }}
-        title="ルール"
-      >
-        ?
-      </button>
+      {/* ヘッダーボタン (常に表示) */}
+      <div style={{ position: 'fixed', top: 12, right: 12, zIndex: 900, display: 'flex', gap: 8 }}>
+        <button
+          onClick={cycleTheme}
+          style={{
+            background: 'var(--bg-secondary)',
+            border: '2px solid var(--accent)',
+            color: 'var(--text-primary)',
+            width: 40,
+            height: 40,
+            borderRadius: '50%',
+            fontSize: 18,
+            cursor: 'pointer',
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+          }}
+          title={`テーマ: ${theme}`}
+        >
+          {THEME_ICONS[theme]}
+        </button>
+        <button
+          onClick={() => setShowRules(true)}
+          style={{
+            background: 'var(--bg-secondary)',
+            border: '2px solid var(--accent)',
+            color: 'var(--text-primary)',
+            width: 40,
+            height: 40,
+            borderRadius: '50%',
+            fontSize: 18,
+            fontWeight: 900,
+            cursor: 'pointer',
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+          }}
+          title="ルール"
+        >
+          ?
+        </button>
+      </div>
 
       {/* ルールモーダル */}
       {showRules && <Rules onClose={() => setShowRules(false)} />}

--- a/client/src/styles/global.css
+++ b/client/src/styles/global.css
@@ -4,7 +4,8 @@
   box-sizing: border-box;
 }
 
-:root {
+/* ダーク（デフォルト） */
+:root, [data-theme="dark"] {
   --bg-primary: #1a1a2e;
   --bg-secondary: #16213e;
   --bg-card: #0f3460;
@@ -16,6 +17,51 @@
   --warning: #feca57;
   --card-bg: #ffffff;
   --card-border: #e94560;
+}
+
+/* ライト */
+[data-theme="light"] {
+  --bg-primary: #f0f2f5;
+  --bg-secondary: #e0e4ea;
+  --bg-card: #6c63ff;
+  --accent: #e94560;
+  --accent-light: #ff6b81;
+  --text-primary: #1a1a2e;
+  --text-secondary: #555;
+  --success: #00b894;
+  --warning: #f39c12;
+  --card-bg: #ffffff;
+  --card-border: #e94560;
+}
+
+/* オーシャン */
+[data-theme="ocean"] {
+  --bg-primary: #0a192f;
+  --bg-secondary: #112240;
+  --bg-card: #1d3a5c;
+  --accent: #64ffda;
+  --accent-light: #8affe8;
+  --text-primary: #ccd6f6;
+  --text-secondary: #8892b0;
+  --success: #64ffda;
+  --warning: #ffd700;
+  --card-bg: #ffffff;
+  --card-border: #64ffda;
+}
+
+/* サクラ */
+[data-theme="sakura"] {
+  --bg-primary: #2d1b2e;
+  --bg-secondary: #3d2640;
+  --bg-card: #5c3d5e;
+  --accent: #ff9eb1;
+  --accent-light: #ffb8c6;
+  --text-primary: #fff0f3;
+  --text-secondary: #d4a0ab;
+  --success: #98d8c8;
+  --warning: #ffd93d;
+  --card-bg: #fff5f7;
+  --card-border: #ff9eb1;
 }
 
 html, body {

--- a/client/src/useTheme.ts
+++ b/client/src/useTheme.ts
@@ -1,0 +1,33 @@
+import { useState, useEffect } from 'react';
+
+export type Theme = 'dark' | 'light' | 'ocean' | 'sakura';
+
+const THEMES: { id: Theme; label: string }[] = [
+  { id: 'dark', label: 'ダーク' },
+  { id: 'light', label: 'ライト' },
+  { id: 'ocean', label: 'オーシャン' },
+  { id: 'sakura', label: 'サクラ' },
+];
+
+function getInitialTheme(): Theme {
+  const stored = localStorage.getItem('dokoda-theme');
+  if (stored && THEMES.some((t) => t.id === stored)) return stored as Theme;
+  if (window.matchMedia('(prefers-color-scheme: light)').matches) return 'light';
+  return 'dark';
+}
+
+export function useTheme() {
+  const [theme, setTheme] = useState<Theme>(getInitialTheme);
+
+  useEffect(() => {
+    document.documentElement.setAttribute('data-theme', theme);
+    localStorage.setItem('dokoda-theme', theme);
+  }, [theme]);
+
+  const cycleTheme = () => {
+    const idx = THEMES.findIndex((t) => t.id === theme);
+    setTheme(THEMES[(idx + 1) % THEMES.length].id);
+  };
+
+  return { theme, setTheme, cycleTheme, themes: THEMES };
+}


### PR DESCRIPTION
## Summary
- ダーク（デフォルト）、ライト、オーシャン、サクラの4テーマを追加
- CSS変数 + `data-theme` 属性で全UIコンポーネントに自動適用
- `localStorage` に保存して次回訪問時も維持
- 初回は `prefers-color-scheme` でシステム設定に追従
- ヘッダーのテーマボタンで順番に切り替え

## Test plan
- [x] ビルド成功、テスト76件パス
- [ ] 各テーマで全画面（Home/Lobby/Game/Result）の表示を確認
- [ ] ライトテーマでカード上のシンボルの視認性確認
- [ ] ブラウザリロード後にテーマが維持されることを確認

Closes #11

🤖 Generated with [Claude Code](https://claude.com/claude-code)