### PR TITLE
feat: 効果音の実装 (#12)

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -7,6 +7,7 @@ import Game from './pages/Game';
 import Result from './pages/Result';
 import Countdown from './pages/Countdown';
 import Rules from './components/Rules';
+import { playCountdown, playStart, playFinish, isMuted, setMuted } from './sounds';
 
 type Page = 'home' | 'lobby' | 'countdown' | 'game' | 'result';
 
@@ -18,6 +19,7 @@ export default function App() {
   const [error, setError] = useState<string | null>(null);
   const [countdownNum, setCountdownNum] = useState(3);
   const [showRules, setShowRules] = useState(false);
+  const [soundMuted, setSoundMuted] = useState(isMuted);
 
   const showError = useCallback((msg: string) => {
     setError(msg);
@@ -39,6 +41,8 @@ export default function App() {
     socket.on('game:countdown', (count: number) => {
       setCountdownNum(count);
       setPage('countdown');
+      if (count > 0) playCountdown();
+      if (count === 0) playStart();
     });
 
     socket.on('game:state', (state: GameState) => {
@@ -51,6 +55,7 @@ export default function App() {
     socket.on('game:finished', (players: Player[]) => {
       setFinalPlayers(players);
       setPage('result');
+      playFinish();
     });
 
     socket.on('error', (message: string) => {
@@ -103,31 +108,64 @@ export default function App() {
         </div>
       )}
 
-      {/* ルールボタン (常に表示) */}
-      <button
-        onClick={() => setShowRules(true)}
-        style={{
-          position: 'fixed',
-          top: 12,
-          right: 12,
-          zIndex: 900,
-          background: 'var(--bg-secondary)',
-          border: '2px solid var(--accent)',
-          color: 'var(--text-primary)',
-          width: 40,
-          height: 40,
-          borderRadius: '50%',
-          fontSize: 18,
-          fontWeight: 900,
-          cursor: 'pointer',
-          display: 'flex',
-          alignItems: 'center',
-          justifyContent: 'center',
-        }}
-        title="ルール"
-      >
-        ?
-      </button>
+      {/* ヘッダーボタン (常に表示) */}
+      <div style={{ position: 'fixed', top: 12, right: 12, zIndex: 900, display: 'flex', gap: 8 }}>
+        <button
+          onClick={() => {
+            const next = !soundMuted;
+            setSoundMuted(next);
+            setMuted(next);
+          }}
+          style={{
+            background: 'var(--bg-secondary)',
+            border: '2px solid var(--accent)',
+            color: 'var(--text-primary)',
+            width: 40,
+            height: 40,
+            borderRadius: '50%',
+            fontSize: 16,
+            cursor: 'pointer',
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+          }}
+          title={soundMuted ? 'サウンドON' : 'サウンドOFF'}
+        >
+          {soundMuted ? (
+            <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+              <polygon points="11 5 6 9 2 9 2 15 6 15 11 19 11 5"/>
+              <line x1="23" y1="9" x2="17" y2="15"/>
+              <line x1="17" y1="9" x2="23" y2="15"/>
+            </svg>
+          ) : (
+            <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+              <polygon points="11 5 6 9 2 9 2 15 6 15 11 19 11 5"/>
+              <path d="M19.07 4.93a10 10 0 0 1 0 14.14"/>
+              <path d="M15.54 8.46a5 5 0 0 1 0 7.07"/>
+            </svg>
+          )}
+        </button>
+        <button
+          onClick={() => setShowRules(true)}
+          style={{
+            background: 'var(--bg-secondary)',
+            border: '2px solid var(--accent)',
+            color: 'var(--text-primary)',
+            width: 40,
+            height: 40,
+            borderRadius: '50%',
+            fontSize: 18,
+            fontWeight: 900,
+            cursor: 'pointer',
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+          }}
+          title="ルール"
+        >
+          ?
+        </button>
+      </div>
 
       {/* ルールモーダル */}
       {showRules && <Rules onClose={() => setShowRules(false)} />}

--- a/client/src/pages/Game.tsx
+++ b/client/src/pages/Game.tsx
@@ -2,6 +2,7 @@ import { useState, useCallback, useEffect, useRef } from 'react';
 import { socket } from '../socket';
 import type { GameState, MatchResult } from 'dokoda-shared';
 import CardView from '../components/Card';
+import { playCorrect, playWrong } from '../sounds';
 
 interface Props {
   gameState: GameState;
@@ -37,11 +38,13 @@ export default function Game({ gameState, myId }: Props) {
   useEffect(() => {
     const handleMatch = (result: MatchResult) => {
       setLastMatch(result);
+      playCorrect();
       setTimeout(() => setLastMatch(null), 1500);
     };
 
     const handleWrong = (data: { cooldownMs: number }) => {
       setCooldown(true);
+      playWrong();
       setTimeout(() => setCooldown(false), Math.max(0, data.cooldownMs));
     };
 

--- a/client/src/sounds.ts
+++ b/client/src/sounds.ts
@@ -1,0 +1,114 @@
+/**
+ * Web Audio API による効果音生成（ファイル不要）
+ */
+
+let audioCtx: AudioContext | null = null;
+let muted = localStorage.getItem('dokoda-muted') === 'true';
+
+function getCtx(): AudioContext | null {
+  if (muted) return null;
+  if (!audioCtx) {
+    audioCtx = new AudioContext();
+  }
+  if (audioCtx.state === 'suspended') {
+    audioCtx.resume();
+  }
+  return audioCtx;
+}
+
+export function isMuted(): boolean {
+  return muted;
+}
+
+export function setMuted(value: boolean): void {
+  muted = value;
+  localStorage.setItem('dokoda-muted', String(value));
+}
+
+/** 正解音: 軽い「ポコッ」 */
+export function playCorrect(): void {
+  const ctx = getCtx();
+  if (!ctx) return;
+  const osc = ctx.createOscillator();
+  const gain = ctx.createGain();
+  osc.connect(gain);
+  gain.connect(ctx.destination);
+  osc.type = 'sine';
+  osc.frequency.setValueAtTime(800, ctx.currentTime);
+  osc.frequency.exponentialRampToValueAtTime(1200, ctx.currentTime + 0.06);
+  gain.gain.setValueAtTime(0.25, ctx.currentTime);
+  gain.gain.exponentialRampToValueAtTime(0.01, ctx.currentTime + 0.15);
+  osc.start();
+  osc.stop(ctx.currentTime + 0.15);
+}
+
+/** 不正解音: 低い「ブッ」 */
+export function playWrong(): void {
+  const ctx = getCtx();
+  if (!ctx) return;
+  const osc = ctx.createOscillator();
+  const gain = ctx.createGain();
+  osc.connect(gain);
+  gain.connect(ctx.destination);
+  osc.type = 'square';
+  osc.frequency.setValueAtTime(200, ctx.currentTime);
+  osc.frequency.exponentialRampToValueAtTime(150, ctx.currentTime + 0.12);
+  gain.gain.setValueAtTime(0.2, ctx.currentTime);
+  gain.gain.exponentialRampToValueAtTime(0.01, ctx.currentTime + 0.12);
+  osc.start();
+  osc.stop(ctx.currentTime + 0.12);
+}
+
+/** ゲーム開始音: 短いビープ「ピッ」 */
+export function playStart(): void {
+  const ctx = getCtx();
+  if (!ctx) return;
+  const osc = ctx.createOscillator();
+  const gain = ctx.createGain();
+  osc.connect(gain);
+  gain.connect(ctx.destination);
+  osc.type = 'sine';
+  osc.frequency.setValueAtTime(880, ctx.currentTime);
+  gain.gain.setValueAtTime(0.3, ctx.currentTime);
+  gain.gain.exponentialRampToValueAtTime(0.01, ctx.currentTime + 0.15);
+  osc.start();
+  osc.stop(ctx.currentTime + 0.15);
+}
+
+/** ゲーム終了音: 長めの「ビビーッ」 */
+export function playFinish(): void {
+  const ctx = getCtx();
+  if (!ctx) return;
+  const t = ctx.currentTime;
+
+  // 2つの音を重ねる
+  for (const freq of [440, 550]) {
+    const osc = ctx.createOscillator();
+    const gain = ctx.createGain();
+    osc.connect(gain);
+    gain.connect(ctx.destination);
+    osc.type = 'square';
+    osc.frequency.setValueAtTime(freq, t);
+    gain.gain.setValueAtTime(0.15, t);
+    gain.gain.setValueAtTime(0.15, t + 0.3);
+    gain.gain.exponentialRampToValueAtTime(0.01, t + 0.5);
+    osc.start(t);
+    osc.stop(t + 0.5);
+  }
+}
+
+/** カウントダウン音: 「ピッ」 */
+export function playCountdown(): void {
+  const ctx = getCtx();
+  if (!ctx) return;
+  const osc = ctx.createOscillator();
+  const gain = ctx.createGain();
+  osc.connect(gain);
+  gain.connect(ctx.destination);
+  osc.type = 'sine';
+  osc.frequency.setValueAtTime(660, ctx.currentTime);
+  gain.gain.setValueAtTime(0.2, ctx.currentTime);
+  gain.gain.exponentialRampToValueAtTime(0.01, ctx.currentTime + 0.1);
+  osc.start();
+  osc.stop(ctx.currentTime + 0.1);
+}


### PR DESCRIPTION
## Summary
- Web Audio API OscillatorNode で全SE をプログラム生成（音声ファイル不要）
- 正解音（ポコッ）、不正解音（ブッ）、カウントダウン音、開始音、終了音
- ミュートボタン + localStorage で設定保存
- モバイルの AudioContext 制約に対応（resume on interaction）

## Test plan
- [x] ビルド成功、テスト76件パス
- [ ] 正解/不正解時に効果音が鳴ることを確認
- [ ] カウントダウン→開始→終了の流れで音が鳴ることを確認
- [ ] ミュートボタンで音がON/OFFされることを確認
- [ ] リロード後もミュート設定が維持されることを確認

Closes #12

🤖 Generated with [Claude Code](https://claude.com/claude-code)