### PR TITLE
feat: マッチハイライト + 触覚フィードバック (#13, #14)

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -8,6 +8,7 @@ import Result from './pages/Result';
 import Countdown from './pages/Countdown';
 import Rules from './components/Rules';
 import { playCountdown, playStart, playFinish, isMuted, setMuted } from './sounds';
+import { vibrateCountdown, vibrateStart, vibrateFinish } from './haptics';
 import { useTheme } from './useTheme';
 
 const THEME_ICONS: Record<string, string> = {
@@ -50,8 +51,8 @@ export default function App() {
     socket.on('game:countdown', (count: number) => {
       setCountdownNum(count);
       setPage('countdown');
-      if (count > 0) playCountdown();
-      if (count === 0) playStart();
+      if (count > 0) { playCountdown(); vibrateCountdown(); }
+      if (count === 0) { playStart(); vibrateStart(); }
     });
 
     socket.on('game:state', (state: GameState) => {
@@ -65,6 +66,7 @@ export default function App() {
       setFinalPlayers(players);
       setPage('result');
       playFinish();
+      vibrateFinish();
     });
 
     socket.on('error', (message: string) => {

--- a/client/src/components/Card.tsx
+++ b/client/src/components/Card.tsx
@@ -8,6 +8,7 @@ interface Props {
   disabled?: boolean;
   size?: number;
   customSymbols?: Record<number, string>;
+  highlightSymbolId?: number | null;
 }
 
 /** カード上のシンボル配置を計算 (8個を円形に配置) */
@@ -40,7 +41,7 @@ function getRotation(symbolId: number, cardId: number): number {
   return ((symbolId * 137 + cardId * 31) % 360);
 }
 
-export default function Card({ card, onSymbolClick, disabled, size, customSymbols }: Props) {
+export default function Card({ card, onSymbolClick, disabled, size, customSymbols, highlightSymbolId }: Props) {
   const defaultSize = Math.min(280, typeof window !== 'undefined' ? window.innerWidth * 0.42 : 280);
   const actualCardSize = size ?? defaultSize;
   const layout = useMemo(() => getSymbolLayout(card.symbols.length), [card.symbols.length]);
@@ -72,6 +73,7 @@ export default function Card({ card, onSymbolClick, disabled, size, customSymbol
         const rotation = getRotation(symbolId, card.id);
         const actualScale = pos.scale;
         const actualSize = symbolSize * actualScale;
+        const isHighlighted = highlightSymbolId === symbolId;
 
         return (
           <button
@@ -83,7 +85,9 @@ export default function Card({ card, onSymbolClick, disabled, size, customSymbol
               position: 'absolute',
               left: `${pos.x}%`,
               top: `${pos.y}%`,
-              transform: `translate(-50%, -50%) rotate(${rotation}deg)`,
+              transform: isHighlighted
+                ? `translate(-50%, -50%) rotate(${rotation}deg) scale(1.35)`
+                : `translate(-50%, -50%) rotate(${rotation}deg)`,
               width: actualSize,
               height: actualSize,
               background: 'transparent',
@@ -93,8 +97,9 @@ export default function Card({ card, onSymbolClick, disabled, size, customSymbol
               display: 'flex',
               alignItems: 'center',
               justifyContent: 'center',
-              transition: 'transform 0.1s',
-              zIndex: index === 0 ? 1 : 0,
+              transition: 'transform 0.2s ease, filter 0.2s ease',
+              zIndex: isHighlighted ? 10 : (index === 0 ? 1 : 0),
+              filter: isHighlighted ? 'drop-shadow(0 0 8px var(--success)) drop-shadow(0 0 16px var(--success))' : 'none',
             }}
             onMouseEnter={(e) => {
               if (!disabled) {

--- a/client/src/haptics.ts
+++ b/client/src/haptics.ts
@@ -1,0 +1,35 @@
+/**
+ * モバイル触覚フィードバック (Vibration API)
+ * 対応ブラウザでのみ動作、非対応では何もしない
+ */
+
+function vibrate(pattern: number | number[]): void {
+  if (typeof navigator !== 'undefined' && navigator.vibrate) {
+    navigator.vibrate(pattern);
+  }
+}
+
+/** 正解マッチ: 短い1回 */
+export function vibrateCorrect(): void {
+  vibrate(40);
+}
+
+/** 不正解: 短い2連打 */
+export function vibrateWrong(): void {
+  vibrate([30, 50, 30]);
+}
+
+/** ゲーム開始 */
+export function vibrateStart(): void {
+  vibrate([50, 30, 50]);
+}
+
+/** ゲーム終了 */
+export function vibrateFinish(): void {
+  vibrate([80, 40, 80, 40, 80]);
+}
+
+/** カウントダウン: 短い1回 */
+export function vibrateCountdown(): void {
+  vibrate(20);
+}

--- a/client/src/pages/Game.tsx
+++ b/client/src/pages/Game.tsx
@@ -3,6 +3,7 @@ import { socket } from '../socket';
 import type { GameState, MatchResult } from 'dokoda-shared';
 import CardView from '../components/Card';
 import { playCorrect, playWrong } from '../sounds';
+import { vibrateCorrect, vibrateWrong } from '../haptics';
 
 interface Props {
   gameState: GameState;
@@ -40,12 +41,14 @@ export default function Game({ gameState, myId, customSymbols }: Props) {
     const handleMatch = (result: MatchResult) => {
       setLastMatch(result);
       playCorrect();
+      vibrateCorrect();
       setTimeout(() => setLastMatch(null), 1500);
     };
 
     const handleWrong = (data: { cooldownMs: number }) => {
       setCooldown(true);
       playWrong();
+      vibrateWrong();
       setTimeout(() => setCooldown(false), Math.max(0, data.cooldownMs));
     };
 
@@ -172,6 +175,7 @@ export default function Game({ gameState, myId, customSymbols }: Props) {
               onSymbolClick={handleSymbolClick}
               disabled={cooldown}
               customSymbols={customSymbols}
+              highlightSymbolId={lastMatch?.symbolId ?? null}
             />
           )}
         </div>
@@ -187,6 +191,7 @@ export default function Game({ gameState, myId, customSymbols }: Props) {
               onSymbolClick={handleSymbolClick}
               disabled={cooldown}
               customSymbols={customSymbols}
+              highlightSymbolId={lastMatch?.symbolId ?? null}
             />
           ) : (
             <div style={{


### PR DESCRIPTION
## Summary
- マッチしたシンボルを両カード上でグロー＋スケールアニメーションでハイライト表示
- Vibration APIによる触覚フィードバック（正解/不正解/カウントダウン/開始/終了）
- 非対応ブラウザでは静かにフォールバック

## Test plan
- [ ] マッチ成功時に両カードで該当シンボルが光って拡大されることを確認
- [ ] 1.5秒後にハイライトが消えることを確認
- [ ] モバイル端末で正解/不正解時にバイブレーションが動作することを確認
- [ ] PC（Vibration API非対応）でエラーなく動作することを確認

Closes #13
Closes #14

🤖 Generated with [Claude Code](https://claude.com/claude-code)