### PR TITLE
feat: 再接続（リコネクション）対応 (#15)

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect, useCallback, useRef } from 'react';
 import { socket } from './socket';
 import type { RoomInfo, GameState, Player } from 'dokoda-shared';
 import Home from './pages/Home';
@@ -17,6 +17,33 @@ const THEME_ICONS: Record<string, string> = {
   sakura: '🌸',
 };
 
+const SESSION_KEY = 'dokoda_session';
+
+interface SessionData {
+  roomCode: string;
+  token: string;
+}
+
+function saveSession(roomCode: string, token: string): void {
+  localStorage.setItem(SESSION_KEY, JSON.stringify({ roomCode, token }));
+}
+
+function loadSession(): SessionData | null {
+  try {
+    const raw = localStorage.getItem(SESSION_KEY);
+    if (!raw) return null;
+    const data = JSON.parse(raw);
+    if (data.roomCode && data.token) return data;
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+function clearSession(): void {
+  localStorage.removeItem(SESSION_KEY);
+}
+
 type Page = 'home' | 'lobby' | 'countdown' | 'game' | 'result';
 
 export default function App() {
@@ -29,17 +56,58 @@ export default function App() {
   const [countdownNum, setCountdownNum] = useState(3);
   const [showRules, setShowRules] = useState(false);
   const [soundMuted, setSoundMuted] = useState(isMuted);
+  const [disconnected, setDisconnected] = useState(false);
+  const [reconnecting, setReconnecting] = useState(false);
+  const rejoinAttempted = useRef(false);
 
   const showError = useCallback((msg: string) => {
     setError(msg);
     setTimeout(() => setError(null), 3000);
   }, []);
 
+  // セッション復帰を試みる
+  const tryRejoin = useCallback(() => {
+    const session = loadSession();
+    if (!session || rejoinAttempted.current) return;
+    rejoinAttempted.current = true;
+    setReconnecting(true);
+
+    socket.emit('room:rejoin', session.roomCode, session.token, (res) => {
+      setReconnecting(false);
+      if (!res.ok) {
+        clearSession();
+        rejoinAttempted.current = false;
+      }
+      // 成功時は room:updated / game:state が届いてページ遷移する
+    });
+  }, []);
+
   useEffect(() => {
     socket.connect();
 
+    socket.on('connect', () => {
+      setDisconnected(false);
+      // ページがhome以外（=ルームにいた）なら再接続を試みる
+      // または初回接続時にセッションがあれば復帰を試みる
+      const session = loadSession();
+      if (session) {
+        rejoinAttempted.current = false;
+        tryRejoin();
+      }
+    });
+
+    socket.on('disconnect', () => {
+      // ルームにいる場合のみ切断オーバーレイを表示
+      const session = loadSession();
+      if (session) {
+        setDisconnected(true);
+      }
+    });
+
     socket.on('room:updated', (roomInfo: RoomInfo) => {
       setRoom(roomInfo);
+      setDisconnected(false);
+      setReconnecting(false);
       if (roomInfo.phase === 'lobby') {
         setPage('lobby');
       } else if (roomInfo.phase === 'countdown') {
@@ -72,23 +140,33 @@ export default function App() {
     });
 
     return () => {
+      socket.off('connect');
+      socket.off('disconnect');
       socket.off('room:updated');
       socket.off('game:state');
       socket.off('game:countdown');
       socket.off('game:finished');
       socket.off('error');
     };
-  }, [showError]);
+  }, [showError, tryRejoin]);
 
   const handleCreate = useCallback((playerName: string) => {
     socket.emit('room:create', playerName, (res) => {
-      if (!res.ok) showError(res.error || '部屋の作成に失敗しました');
+      if (!res.ok) {
+        showError(res.error || '部屋の作成に失敗しました');
+      } else if (res.code && res.token) {
+        saveSession(res.code, res.token);
+      }
     });
   }, [showError]);
 
   const handleJoin = useCallback((code: string, playerName: string) => {
     socket.emit('room:join', code, playerName, (res) => {
-      if (!res.ok) showError(res.error || '部屋への参加に失敗しました');
+      if (!res.ok) {
+        showError(res.error || '部屋への参加に失敗しました');
+      } else if (res.token) {
+        saveSession(code.trim().toUpperCase(), res.token);
+      }
     });
   }, [showError]);
 
@@ -96,8 +174,64 @@ export default function App() {
     socket.emit('game:backToLobby');
   }, []);
 
+  // ホームに戻る時はセッションをクリア
+  const handleGoHome = useCallback(() => {
+    clearSession();
+    setRoom(null);
+    setGameState(null);
+    setFinalPlayers([]);
+    setPage('home');
+  }, []);
+
+  // ホーム画面での復帰ボタン
+  const handleRejoinFromHome = useCallback(() => {
+    const session = loadSession();
+    if (!session) return;
+    setReconnecting(true);
+    rejoinAttempted.current = false;
+    tryRejoin();
+  }, [tryRejoin]);
+
+  const savedSession = page === 'home' ? loadSession() : null;
+
   return (
     <div style={{ height: '100%', position: 'relative' }}>
+      {/* 切断オーバーレイ */}
+      {disconnected && page !== 'home' && (
+        <div style={{
+          position: 'fixed',
+          inset: 0,
+          background: 'rgba(0, 0, 0, 0.85)',
+          zIndex: 2000,
+          display: 'flex',
+          flexDirection: 'column',
+          alignItems: 'center',
+          justifyContent: 'center',
+          gap: 16,
+        }}>
+          <div style={{
+            width: 40, height: 40,
+            border: '4px solid var(--accent)',
+            borderTopColor: 'transparent',
+            borderRadius: '50%',
+            animation: 'spin 1s linear infinite',
+          }} />
+          <p style={{ color: 'white', fontSize: 18, fontWeight: 700 }}>
+            再接続中...
+          </p>
+          <p style={{ color: 'var(--text-secondary)', fontSize: 13 }}>
+            接続が切れました。自動的に再接続を試みています
+          </p>
+          <button
+            className="btn-primary"
+            style={{ marginTop: 16, fontSize: 14 }}
+            onClick={handleGoHome}
+          >
+            ホームに戻る
+          </button>
+        </div>
+      )}
+
       {/* エラー表示 */}
       {error && (
         <div style={{
@@ -200,7 +334,39 @@ export default function App() {
 
       {/* ページ */}
       {page === 'home' && (
-        <Home onCreateRoom={handleCreate} onJoinRoom={handleJoin} />
+        <>
+          <Home onCreateRoom={handleCreate} onJoinRoom={handleJoin} />
+          {savedSession && !reconnecting && (
+            <div style={{
+              position: 'fixed',
+              bottom: 20,
+              left: '50%',
+              transform: 'translateX(-50%)',
+              zIndex: 800,
+            }}>
+              <button
+                className="btn-primary"
+                onClick={handleRejoinFromHome}
+                style={{ fontSize: 14, padding: '10px 24px' }}
+              >
+                ルームに戻る ({savedSession.roomCode})
+              </button>
+            </div>
+          )}
+          {reconnecting && (
+            <div style={{
+              position: 'fixed',
+              bottom: 20,
+              left: '50%',
+              transform: 'translateX(-50%)',
+              zIndex: 800,
+              color: 'var(--text-secondary)',
+              fontSize: 14,
+            }}>
+              再接続中...
+            </div>
+          )}
+        </>
       )}
       {page === 'lobby' && room && (
         <Lobby room={room} myId={socket.id || ''} />

--- a/client/src/styles/global.css
+++ b/client/src/styles/global.css
@@ -159,3 +159,7 @@ input[type="text"]:focus {
   50% { background: rgba(0, 210, 211, 0.3); }
   100% { background: rgba(0, 210, 211, 0); }
 }
+
+@keyframes spin {
+  to { transform: rotate(360deg); }
+}

--- a/server/src/__tests__/game.test.ts
+++ b/server/src/__tests__/game.test.ts
@@ -20,7 +20,7 @@ function createMockSocket(id: string) {
 
 function createRoomWithPlayers(manager: RoomManager, count: number): Room {
   const host = createMockSocket('player-0');
-  const room = manager.createRoom(host, 'Player0');
+  const { room } = manager.createRoom(host, 'Player0');
 
   for (let i = 1; i < count; i++) {
     const socket = createMockSocket(`player-${i}`);

--- a/server/src/__tests__/room.test.ts
+++ b/server/src/__tests__/room.test.ts
@@ -19,7 +19,7 @@ describe('RoomManager', () => {
   describe('createRoom', () => {
     it('creates a room with correct initial state', () => {
       const socket = createMockSocket('socket-1');
-      const room = manager.createRoom(socket, 'Player1');
+      const { room, token } = manager.createRoom(socket, 'Player1');
 
       expect(room.code).toHaveLength(4);
       expect(room.phase).toBe('lobby');
@@ -31,11 +31,12 @@ describe('RoomManager', () => {
       expect(room.countdownTimer).toBeNull();
       expect(room.timeAttackTimer).toBeNull();
       expect(room.finishedAt).toBe(0);
+      expect(token).toBeTruthy();
     });
 
     it('host player has correct properties', () => {
       const socket = createMockSocket('socket-1');
-      const room = manager.createRoom(socket, 'Host');
+      const { room } = manager.createRoom(socket, 'Host');
       const player = room.players.get('socket-1');
 
       expect(player).toBeDefined();
@@ -44,11 +45,12 @@ describe('RoomManager', () => {
       expect(player!.connected).toBe(true);
       expect(player!.score).toBe(0);
       expect(player!.hand).toEqual([]);
+      expect(player!.reconnectToken).toBeTruthy();
     });
 
     it('socket joins the room code', () => {
       const socket = createMockSocket('socket-1');
-      const room = manager.createRoom(socket, 'Player1');
+      const { room } = manager.createRoom(socket, 'Player1');
       expect(socket.join).toHaveBeenCalledWith(room.code);
     });
 
@@ -56,7 +58,7 @@ describe('RoomManager', () => {
       const codes = new Set<string>();
       for (let i = 0; i < 20; i++) {
         const socket = createMockSocket(`socket-${i}`);
-        const room = manager.createRoom(socket, `Player${i}`);
+        const { room } = manager.createRoom(socket, `Player${i}`);
         codes.add(room.code);
       }
       expect(codes.size).toBe(20);
@@ -66,12 +68,13 @@ describe('RoomManager', () => {
   describe('joinRoom', () => {
     it('joins an existing room', () => {
       const host = createMockSocket('host');
-      const room = manager.createRoom(host, 'Host');
+      const { room } = manager.createRoom(host, 'Host');
 
       const joiner = createMockSocket('joiner');
       const result = manager.joinRoom(joiner, room.code, 'Joiner');
 
       expect(result.ok).toBe(true);
+      expect(result.token).toBeTruthy();
       expect(room.players.size).toBe(2);
     });
 
@@ -83,7 +86,7 @@ describe('RoomManager', () => {
 
     it('rejects join during non-lobby phase', () => {
       const host = createMockSocket('host');
-      const room = manager.createRoom(host, 'Host');
+      const { room } = manager.createRoom(host, 'Host');
       room.phase = 'playing';
 
       const result = manager.joinRoom(createMockSocket('s1'), room.code, 'Late');
@@ -93,7 +96,7 @@ describe('RoomManager', () => {
 
     it('rejects duplicate player name', () => {
       const host = createMockSocket('host');
-      const room = manager.createRoom(host, 'Same');
+      const { room } = manager.createRoom(host, 'Same');
 
       const result = manager.joinRoom(createMockSocket('s1'), room.code, 'Same');
       expect(result.ok).toBe(false);
@@ -102,7 +105,7 @@ describe('RoomManager', () => {
 
     it('rejects when room is full (8 players)', () => {
       const host = createMockSocket('host');
-      const room = manager.createRoom(host, 'Host');
+      const { room } = manager.createRoom(host, 'Host');
 
       for (let i = 1; i < 8; i++) {
         manager.joinRoom(createMockSocket(`s${i}`), room.code, `P${i}`);
@@ -116,7 +119,7 @@ describe('RoomManager', () => {
 
     it('is case-insensitive for room code', () => {
       const host = createMockSocket('host');
-      const room = manager.createRoom(host, 'Host');
+      const { room } = manager.createRoom(host, 'Host');
 
       const result = manager.joinRoom(
         createMockSocket('joiner'),
@@ -127,34 +130,53 @@ describe('RoomManager', () => {
     });
   });
 
-  describe('leaveRoom', () => {
-    it('removes player from room', () => {
+  describe('disconnectPlayer', () => {
+    it('marks player as disconnected', () => {
       const host = createMockSocket('host');
-      const room = manager.createRoom(host, 'Host');
+      const { room } = manager.createRoom(host, 'Host');
       const joiner = createMockSocket('joiner');
       manager.joinRoom(joiner, room.code, 'Joiner');
 
-      const result = manager.leaveRoom('joiner');
+      const result = manager.disconnectPlayer('joiner', () => {});
+      expect(result).not.toBeNull();
+      expect(result!.player.connected).toBe(false);
+      expect(room.players.size).toBe(2); // still in room
+      expect(room.disconnectTimers.has('joiner')).toBe(true);
+    });
+
+    it('returns null for unknown socket', () => {
+      expect(manager.disconnectPlayer('unknown', () => {})).toBeNull();
+    });
+  });
+
+  describe('removePlayer', () => {
+    it('removes player from room', () => {
+      const host = createMockSocket('host');
+      const { room } = manager.createRoom(host, 'Host');
+      const joiner = createMockSocket('joiner');
+      manager.joinRoom(joiner, room.code, 'Joiner');
+
+      const result = manager.removePlayer('joiner');
       expect(result).not.toBeNull();
       expect(result!.leftPlayer.name).toBe('Joiner');
       expect(room.players.size).toBe(1);
     });
 
-    it('deletes room when last player leaves', () => {
+    it('deletes room when last player is removed', () => {
       const host = createMockSocket('host');
-      const room = manager.createRoom(host, 'Host');
+      const { room } = manager.createRoom(host, 'Host');
 
-      manager.leaveRoom('host');
+      manager.removePlayer('host');
       expect(manager.getRoom(room.code)).toBeUndefined();
     });
 
-    it('promotes next player to host when host leaves', () => {
+    it('promotes next player to host when host is removed', () => {
       const host = createMockSocket('host');
-      const room = manager.createRoom(host, 'Host');
+      const { room } = manager.createRoom(host, 'Host');
       const joiner = createMockSocket('joiner');
       manager.joinRoom(joiner, room.code, 'Joiner');
 
-      manager.leaveRoom('host');
+      manager.removePlayer('host');
       const newHost = room.players.get('joiner');
       expect(newHost!.isHost).toBe(true);
       expect(room.hostId).toBe('joiner');
@@ -162,7 +184,7 @@ describe('RoomManager', () => {
 
     it('clears timers when room is emptied', () => {
       const host = createMockSocket('host');
-      const room = manager.createRoom(host, 'Host');
+      const { room } = manager.createRoom(host, 'Host');
 
       const clearIntervalSpy = vi.spyOn(global, 'clearInterval');
       const clearTimeoutSpy = vi.spyOn(global, 'clearTimeout');
@@ -170,7 +192,7 @@ describe('RoomManager', () => {
       room.countdownTimer = setInterval(() => {}, 1000);
       room.timeAttackTimer = setTimeout(() => {}, 1000);
 
-      manager.leaveRoom('host');
+      manager.removePlayer('host');
 
       expect(clearIntervalSpy).toHaveBeenCalled();
       expect(clearTimeoutSpy).toHaveBeenCalled();
@@ -180,14 +202,87 @@ describe('RoomManager', () => {
     });
 
     it('returns null for unknown socket', () => {
-      expect(manager.leaveRoom('unknown')).toBeNull();
+      expect(manager.removePlayer('unknown')).toBeNull();
+    });
+  });
+
+  describe('rejoinRoom', () => {
+    it('reconnects a disconnected player with new socket', () => {
+      const host = createMockSocket('host');
+      const { room, token } = manager.createRoom(host, 'Host');
+
+      // Disconnect host
+      manager.disconnectPlayer('host', () => {});
+      expect(room.players.get('host')!.connected).toBe(false);
+
+      // Rejoin with new socket
+      const newSocket = createMockSocket('host-new');
+      const result = manager.rejoinRoom(newSocket, room.code, token);
+
+      expect(result.ok).toBe(true);
+      expect(room.players.has('host')).toBe(false);
+      expect(room.players.has('host-new')).toBe(true);
+      expect(room.players.get('host-new')!.connected).toBe(true);
+      expect(room.players.get('host-new')!.name).toBe('Host');
+      expect(room.hostId).toBe('host-new');
+    });
+
+    it('preserves hand and score on rejoin', () => {
+      const host = createMockSocket('host');
+      const { room, token } = manager.createRoom(host, 'Host');
+      const player = room.players.get('host')!;
+      player.hand = [{ id: 1, symbols: [0, 1, 2] }];
+      player.score = 5;
+
+      manager.disconnectPlayer('host', () => {});
+
+      const newSocket = createMockSocket('host-new');
+      manager.rejoinRoom(newSocket, room.code, token);
+
+      const reconnected = room.players.get('host-new')!;
+      expect(reconnected.hand).toEqual([{ id: 1, symbols: [0, 1, 2] }]);
+      expect(reconnected.score).toBe(5);
+    });
+
+    it('rejects invalid token', () => {
+      const host = createMockSocket('host');
+      const { room } = manager.createRoom(host, 'Host');
+
+      manager.disconnectPlayer('host', () => {});
+
+      const newSocket = createMockSocket('host-new');
+      const result = manager.rejoinRoom(newSocket, room.code, 'bad-token');
+      expect(result.ok).toBe(false);
+    });
+
+    it('rejects invalid room code', () => {
+      const host = createMockSocket('host');
+      const { token } = manager.createRoom(host, 'Host');
+
+      manager.disconnectPlayer('host', () => {});
+
+      const newSocket = createMockSocket('host-new');
+      const result = manager.rejoinRoom(newSocket, 'ZZZZ', token);
+      expect(result.ok).toBe(false);
+    });
+
+    it('cancels grace timer on rejoin', () => {
+      const host = createMockSocket('host');
+      const { room, token } = manager.createRoom(host, 'Host');
+
+      manager.disconnectPlayer('host', () => {});
+      expect(room.disconnectTimers.has('host')).toBe(true);
+
+      const newSocket = createMockSocket('host-new');
+      manager.rejoinRoom(newSocket, room.code, token);
+      expect(room.disconnectTimers.has('host')).toBe(false);
     });
   });
 
   describe('backToLobby', () => {
     it('resets room state to lobby', () => {
       const host = createMockSocket('host');
-      const room = manager.createRoom(host, 'Host');
+      const { room } = manager.createRoom(host, 'Host');
 
       room.phase = 'finished';
       room.centerCard = { id: 0, symbols: [0, 1, 2] };
@@ -212,12 +307,26 @@ describe('RoomManager', () => {
       expect(player.score).toBe(0);
       expect(player.hand).toEqual([]);
     });
+
+    it('removes disconnected players when returning to lobby', () => {
+      const host = createMockSocket('host');
+      const { room } = manager.createRoom(host, 'Host');
+      const joiner = createMockSocket('joiner');
+      manager.joinRoom(joiner, room.code, 'Joiner');
+
+      room.phase = 'finished';
+      manager.disconnectPlayer('joiner', () => {});
+
+      manager.backToLobby(room);
+      expect(room.players.size).toBe(1);
+      expect(room.players.has('joiner')).toBe(false);
+    });
   });
 
   describe('getRoomBySocketId', () => {
     it('finds room by socket id', () => {
       const socket = createMockSocket('socket-1');
-      const room = manager.createRoom(socket, 'Player');
+      const { room } = manager.createRoom(socket, 'Player');
 
       expect(manager.getRoomBySocketId('socket-1')).toBe(room);
     });
@@ -230,7 +339,7 @@ describe('RoomManager', () => {
   describe('getRoomInfo', () => {
     it('returns client-safe room info', () => {
       const socket = createMockSocket('host');
-      const room = manager.createRoom(socket, 'Host');
+      const { room } = manager.createRoom(socket, 'Host');
 
       const info = manager.getRoomInfo(room);
 
@@ -243,6 +352,7 @@ describe('RoomManager', () => {
       expect((info.players[0] as any).hand).toBeUndefined();
       expect((info.players[0] as any).socketId).toBeUndefined();
       expect((info.players[0] as any).cooldownUntil).toBeUndefined();
+      expect((info.players[0] as any).reconnectToken).toBeUndefined();
     });
   });
 
@@ -251,13 +361,13 @@ describe('RoomManager', () => {
 
     it('room starts with empty customSymbols', () => {
       const socket = createMockSocket('host');
-      const room = manager.createRoom(socket, 'Host');
+      const { room } = manager.createRoom(socket, 'Host');
       expect(room.customSymbols.size).toBe(0);
     });
 
     it('host can upload a custom symbol', () => {
       const socket = createMockSocket('host');
-      const room = manager.createRoom(socket, 'Host');
+      const { room } = manager.createRoom(socket, 'Host');
 
       const result = manager.uploadSymbol(room, 'host', 0, VALID_DATA_URL);
       expect(result.ok).toBe(true);
@@ -266,7 +376,7 @@ describe('RoomManager', () => {
 
     it('non-host cannot upload', () => {
       const host = createMockSocket('host');
-      const room = manager.createRoom(host, 'Host');
+      const { room } = manager.createRoom(host, 'Host');
       manager.joinRoom(createMockSocket('joiner'), room.code, 'Joiner');
 
       const result = manager.uploadSymbol(room, 'joiner', 0, VALID_DATA_URL);
@@ -276,7 +386,7 @@ describe('RoomManager', () => {
 
     it('rejects upload during non-lobby phase', () => {
       const socket = createMockSocket('host');
-      const room = manager.createRoom(socket, 'Host');
+      const { room } = manager.createRoom(socket, 'Host');
       room.phase = 'playing';
 
       const result = manager.uploadSymbol(room, 'host', 0, VALID_DATA_URL);
@@ -285,7 +395,7 @@ describe('RoomManager', () => {
 
     it('rejects invalid symbol ID', () => {
       const socket = createMockSocket('host');
-      const room = manager.createRoom(socket, 'Host');
+      const { room } = manager.createRoom(socket, 'Host');
 
       expect(manager.uploadSymbol(room, 'host', -1, VALID_DATA_URL).ok).toBe(false);
       expect(manager.uploadSymbol(room, 'host', 57, VALID_DATA_URL).ok).toBe(false);
@@ -294,7 +404,7 @@ describe('RoomManager', () => {
 
     it('rejects non-image data URL', () => {
       const socket = createMockSocket('host');
-      const room = manager.createRoom(socket, 'Host');
+      const { room } = manager.createRoom(socket, 'Host');
 
       expect(manager.uploadSymbol(room, 'host', 0, 'not-a-data-url').ok).toBe(false);
       expect(manager.uploadSymbol(room, 'host', 0, 'data:text/plain;base64,abc').ok).toBe(false);
@@ -302,7 +412,7 @@ describe('RoomManager', () => {
 
     it('rejects oversized data URL', () => {
       const socket = createMockSocket('host');
-      const room = manager.createRoom(socket, 'Host');
+      const { room } = manager.createRoom(socket, 'Host');
 
       const big = 'data:image/png;base64,' + 'A'.repeat(300 * 1024);
       expect(manager.uploadSymbol(room, 'host', 0, big).ok).toBe(false);
@@ -310,7 +420,7 @@ describe('RoomManager', () => {
 
     it('host can delete a custom symbol', () => {
       const socket = createMockSocket('host');
-      const room = manager.createRoom(socket, 'Host');
+      const { room } = manager.createRoom(socket, 'Host');
       manager.uploadSymbol(room, 'host', 5, VALID_DATA_URL);
 
       expect(manager.deleteSymbol(room, 'host', 5)).toBe(true);
@@ -319,7 +429,7 @@ describe('RoomManager', () => {
 
     it('host can reset all custom symbols', () => {
       const socket = createMockSocket('host');
-      const room = manager.createRoom(socket, 'Host');
+      const { room } = manager.createRoom(socket, 'Host');
       manager.uploadSymbol(room, 'host', 0, VALID_DATA_URL);
       manager.uploadSymbol(room, 'host', 1, VALID_DATA_URL);
 
@@ -329,7 +439,7 @@ describe('RoomManager', () => {
 
     it('getRoomInfo includes customSymbols as plain object', () => {
       const socket = createMockSocket('host');
-      const room = manager.createRoom(socket, 'Host');
+      const { room } = manager.createRoom(socket, 'Host');
       manager.uploadSymbol(room, 'host', 3, VALID_DATA_URL);
 
       const info = manager.getRoomInfo(room);
@@ -340,7 +450,7 @@ describe('RoomManager', () => {
   describe('cleanupInactiveRooms', () => {
     it('removes rooms past timeout', () => {
       const socket = createMockSocket('host');
-      const room = manager.createRoom(socket, 'Host');
+      const { room } = manager.createRoom(socket, 'Host');
 
       // Set lastActivity to 31 minutes ago
       room.lastActivity = Date.now() - 31 * 60 * 1000;
@@ -352,7 +462,7 @@ describe('RoomManager', () => {
 
     it('keeps active rooms', () => {
       const socket = createMockSocket('host');
-      const room = manager.createRoom(socket, 'Host');
+      const { room } = manager.createRoom(socket, 'Host');
 
       const count = manager.cleanupInactiveRooms();
       expect(count).toBe(0);

--- a/server/src/events.ts
+++ b/server/src/events.ts
@@ -1,6 +1,7 @@
 import { Server, Socket } from 'socket.io';
 import {
   GameSettings,
+  Player,
   ServerToClientEvents,
   ClientToServerEvents,
   MIN_PLAYERS,
@@ -10,12 +11,71 @@ import {
   MAX_TIME_LIMIT_SEC,
   getMinCards,
 } from 'dokoda-shared';
-import { RoomManager } from './room.js';
+import { Room, ServerPlayer, RoomManager } from './room.js';
 import { GameEngine } from './game.js';
 import { checkRateLimit, cleanupRateLimit } from './rateLimit.js';
 
 type TypedIO = Server<ClientToServerEvents, ServerToClientEvents>;
 type TypedSocket = Socket<ClientToServerEvents, ServerToClientEvents>;
+
+/** 猶予期間超過後のプレイヤー除外処理 */
+function handleGraceExpired(
+  io: TypedIO,
+  roomManager: RoomManager,
+  gameEngine: GameEngine,
+  room: Room,
+  player: ServerPlayer
+): void {
+  if (room.players.size === 0) return;
+
+  const roomInfo = roomManager.getRoomInfo(room);
+  io.to(room.code).emit('room:updated', roomInfo);
+
+  // カウントダウン中に人数不足になったらロビーに戻す
+  if (room.phase === 'countdown') {
+    const connectedCount = Array.from(room.players.values()).filter(p => p.connected).length;
+    const minForStart = room.mode === 'timeAttack' ? 1 : MIN_PLAYERS;
+    if (connectedCount < minForStart) {
+      if (room.countdownTimer) {
+        clearInterval(room.countdownTimer);
+        room.countdownTimer = null;
+      }
+      room.phase = 'lobby';
+      const updatedInfo = roomManager.getRoomInfo(room);
+      io.to(room.code).emit('room:updated', updatedInfo);
+    }
+  }
+
+  // ゲーム中にプレイヤー不足で強制終了
+  const minPlayersForGame = room.mode === 'timeAttack' ? 1 : MIN_PLAYERS;
+  if (room.phase === 'playing' && room.players.size < minPlayersForGame) {
+    room.phase = 'finished';
+    room.finishedAt = Date.now();
+    if (room.timeAttackTimer) {
+      clearTimeout(room.timeAttackTimer);
+      room.timeAttackTimer = null;
+    }
+    const players: Player[] = Array.from(room.players.values()).map((p) => ({
+      id: p.id,
+      name: p.name,
+      score: p.score,
+      cardCount: p.hand.length,
+      connected: p.connected,
+      isHost: p.isHost,
+    }));
+    io.to(room.code).emit('game:finished', players);
+
+    for (const p of room.players.values()) {
+      const state = gameEngine.getGameStateForPlayer(room, p.socketId);
+      io.to(p.socketId).emit('game:state', state);
+    }
+
+    const updatedRoomInfo = roomManager.getRoomInfo(room);
+    io.to(room.code).emit('room:updated', updatedRoomInfo);
+  }
+
+  console.log(`[猶予期間超過] ${player.name} from ${room.code}`);
+}
 
 export function setupSocketEvents(
   io: TypedIO,
@@ -49,11 +109,11 @@ export function setupSocketEvents(
         return;
       }
 
-      const room = roomManager.createRoom(socket, trimmedName);
+      const { room, token } = roomManager.createRoom(socket, trimmedName);
       const roomInfo = roomManager.getRoomInfo(room);
       io.to(room.code).emit('room:updated', roomInfo);
 
-      callback({ ok: true, code: room.code });
+      callback({ ok: true, code: room.code, token });
       console.log(`[ルーム作成] ${room.code} by ${trimmedName}`);
     });
 
@@ -101,8 +161,58 @@ export function setupSocketEvents(
       const roomInfo = roomManager.getRoomInfo(result.room!);
       io.to(result.room!.code).emit('room:updated', roomInfo);
 
-      callback({ ok: true });
+      callback({ ok: true, token: result.token });
       console.log(`[ルーム参加] ${trimmedCode} by ${trimmedName}`);
+    });
+
+    // --- 再接続 ---
+    socket.on('room:rejoin', (code, token, callback) => {
+      if (!checkRateLimit(socket.id, 'room:rejoin')) {
+        callback({ ok: false, error: 'リクエストが多すぎます' });
+        return;
+      }
+
+      if (!code || typeof code !== 'string' || !token || typeof token !== 'string') {
+        callback({ ok: false, error: '無効なリクエストです' });
+        return;
+      }
+
+      const existingRoom = roomManager.getRoomBySocketId(socket.id);
+      if (existingRoom) {
+        callback({ ok: false, error: '既にルームに参加しています' });
+        return;
+      }
+
+      const result = roomManager.rejoinRoom(socket, code.toUpperCase(), token);
+      if (!result.ok) {
+        callback({ ok: false, error: result.error });
+        return;
+      }
+
+      const room = result.room!;
+      const roomInfo = roomManager.getRoomInfo(room);
+      io.to(room.code).emit('room:updated', roomInfo);
+
+      // ゲーム中なら最新のゲーム状態を送信
+      if (room.phase === 'playing' || room.phase === 'finished') {
+        const state = gameEngine.getGameStateForPlayer(room, socket.id);
+        socket.emit('game:state', state);
+
+        if (room.phase === 'finished') {
+          const players: Player[] = Array.from(room.players.values()).map((p) => ({
+            id: p.id,
+            name: p.name,
+            score: p.score,
+            cardCount: p.hand.length,
+            connected: p.connected,
+            isHost: p.isHost,
+          }));
+          socket.emit('game:finished', players);
+        }
+      }
+
+      callback({ ok: true });
+      console.log(`[再接続] ${code} socket=${socket.id}`);
     });
 
     // --- ゲーム設定変更 (ホストのみ) ---
@@ -246,57 +356,28 @@ export function setupSocketEvents(
       console.log(`[切断] ${socket.id}`);
       cleanupRateLimit(socket.id);
 
-      const result = roomManager.leaveRoom(socket.id);
+      const result = roomManager.disconnectPlayer(
+        socket.id,
+        (room, player) => handleGraceExpired(io, roomManager, gameEngine, room, player)
+      );
+
       if (result) {
-        const { room, leftPlayer } = result;
+        const { room, player } = result;
+        // 切断状態を他のプレイヤーに通知
+        const roomInfo = roomManager.getRoomInfo(room);
+        io.to(room.code).emit('room:updated', roomInfo);
 
-        if (room.players.size > 0) {
-          const roomInfo = roomManager.getRoomInfo(room);
-          io.to(room.code).emit('room:updated', roomInfo);
-
-          // カウントダウン中に人数不足になったらロビーに戻す
-          if (room.phase === 'countdown') {
-            const minForStart = room.mode === 'timeAttack' ? 1 : MIN_PLAYERS;
-            if (room.players.size < minForStart) {
-              if (room.countdownTimer) {
-                clearInterval(room.countdownTimer);
-                room.countdownTimer = null;
-              }
-              room.phase = 'lobby';
-              const updatedInfo = roomManager.getRoomInfo(room);
-              io.to(room.code).emit('room:updated', updatedInfo);
-            }
-          }
-
-          const minPlayersForGame = room.mode === 'timeAttack' ? 1 : MIN_PLAYERS;
-          if (room.phase === 'playing' && room.players.size < minPlayersForGame) {
-            room.phase = 'finished';
-            room.finishedAt = Date.now();
-            if (room.timeAttackTimer) {
-              clearTimeout(room.timeAttackTimer);
-              room.timeAttackTimer = null;
-            }
-            const players = Array.from(room.players.values()).map((p) => ({
-              id: p.id,
-              name: p.name,
-              score: p.score,
-              cardCount: p.hand.length,
-              connected: p.connected,
-              isHost: p.isHost,
-            }));
-            io.to(room.code).emit('game:finished', players);
-
-            for (const p of room.players.values()) {
+        // ゲーム中なら全員のゲーム状態を更新（切断表示）
+        if (room.phase === 'playing') {
+          for (const p of room.players.values()) {
+            if (p.connected) {
               const state = gameEngine.getGameStateForPlayer(room, p.socketId);
               io.to(p.socketId).emit('game:state', state);
             }
-
-            const updatedRoomInfo = roomManager.getRoomInfo(room);
-            io.to(room.code).emit('room:updated', updatedRoomInfo);
           }
         }
 
-        console.log(`[退出] ${leftPlayer.name} from ${room.code}`);
+        console.log(`[切断中] ${player.name} from ${room.code} (猶予期間開始)`);
       }
     });
   });

--- a/server/src/rateLimit.ts
+++ b/server/src/rateLimit.ts
@@ -16,6 +16,7 @@ const EVENT_LIMITS: Record<string, RateLimitConfig> = {
   // ルーム操作（低頻度で十分）
   'room:create': { windowMs: 5000, maxRequests: 3 },
   'room:join': { windowMs: 5000, maxRequests: 5 },
+  'room:rejoin': { windowMs: 5000, maxRequests: 5 },
   'room:settings': { windowMs: 1000, maxRequests: 5 },
   'game:start': { windowMs: 5000, maxRequests: 3 },
   'game:backToLobby': { windowMs: 3000, maxRequests: 3 },

--- a/server/src/room.ts
+++ b/server/src/room.ts
@@ -1,3 +1,4 @@
+import crypto from 'node:crypto';
 import { Socket } from 'socket.io';
 import {
   Card,
@@ -17,6 +18,7 @@ import {
   MAX_CUSTOM_SYMBOL_SIZE,
   MAX_CUSTOM_SYMBOLS,
   TOTAL_SYMBOLS,
+  RECONNECT_GRACE_MS,
 } from 'dokoda-shared';
 
 /** サーバー側のプレイヤー情報（クライアントに送らない情報を含む） */
@@ -24,6 +26,7 @@ export interface ServerPlayer extends Player {
   socketId: string;
   hand: Card[];
   cooldownUntil: number;
+  reconnectToken: string;
 }
 
 /** サーバー側のルーム情報 */
@@ -45,6 +48,7 @@ export interface Room {
   timeAttackTimer: ReturnType<typeof setTimeout> | null;
   countdownTimer: ReturnType<typeof setInterval> | null;
   customSymbols: Map<number, string>; // symbolId -> base64 data URL
+  disconnectTimers: Map<string, ReturnType<typeof setTimeout>>; // socketId -> grace timer
 }
 
 type TypedSocket = Socket<ClientToServerEvents, ServerToClientEvents>;
@@ -53,8 +57,9 @@ export class RoomManager {
   private rooms = new Map<string, Room>();
 
   /** ルームを作成し、作成者をホストとして追加 */
-  createRoom(socket: TypedSocket, playerName: string): Room {
+  createRoom(socket: TypedSocket, playerName: string): { room: Room; token: string } {
     const code = this.generateRoomCode();
+    const token = this.generateToken();
 
     const player: ServerPlayer = {
       id: socket.id,
@@ -66,6 +71,7 @@ export class RoomManager {
       isHost: true,
       hand: [],
       cooldownUntil: 0,
+      reconnectToken: token,
     };
 
     const room: Room = {
@@ -91,12 +97,13 @@ export class RoomManager {
       timeAttackTimer: null,
       countdownTimer: null,
       customSymbols: new Map(),
+      disconnectTimers: new Map(),
     };
 
     this.rooms.set(code, room);
     socket.join(code);
 
-    return room;
+    return { room, token };
   }
 
   /** 既存のルームに参加 */
@@ -104,7 +111,7 @@ export class RoomManager {
     socket: TypedSocket,
     code: string,
     playerName: string
-  ): { ok: boolean; room?: Room; error?: string } {
+  ): { ok: boolean; room?: Room; token?: string; error?: string } {
     const room = this.rooms.get(code.toUpperCase());
     if (!room) {
       return { ok: false, error: 'ルームが見つかりません' };
@@ -125,6 +132,7 @@ export class RoomManager {
       }
     }
 
+    const token = this.generateToken();
     const player: ServerPlayer = {
       id: socket.id,
       socketId: socket.id,
@@ -135,13 +143,14 @@ export class RoomManager {
       isHost: false,
       hand: [],
       cooldownUntil: 0,
+      reconnectToken: token,
     };
 
     room.players.set(socket.id, player);
     room.lastActivity = Date.now();
     socket.join(code);
 
-    return { ok: true, room };
+    return { ok: true, room, token };
   }
 
   /** ゲーム終了後にロビーに戻す */
@@ -164,6 +173,18 @@ export class RoomManager {
       room.countdownTimer = null;
     }
 
+    // 切断中プレイヤーを除外（ロビーに戻る時は切断者は除外）
+    for (const [sid, player] of room.players) {
+      if (!player.connected) {
+        room.players.delete(sid);
+        const timer = room.disconnectTimers.get(sid);
+        if (timer) {
+          clearTimeout(timer);
+          room.disconnectTimers.delete(sid);
+        }
+      }
+    }
+
     for (const player of room.players.values()) {
       player.hand = [];
       player.cardCount = 0;
@@ -172,17 +193,55 @@ export class RoomManager {
     }
   }
 
-  /** プレイヤーがルームから退出（切断含む） */
-  leaveRoom(socketId: string): { room: Room; leftPlayer: ServerPlayer } | null {
+  /** プレイヤーを切断状態にする（猶予期間後に除外） */
+  disconnectPlayer(socketId: string, onGraceExpired: (room: Room, player: ServerPlayer) => void): { room: Room; player: ServerPlayer } | null {
+    for (const room of this.rooms.values()) {
+      const player = room.players.get(socketId);
+      if (!player) continue;
+
+      player.connected = false;
+      room.lastActivity = Date.now();
+
+      // 猶予タイマーを設定
+      const timer = setTimeout(() => {
+        room.disconnectTimers.delete(socketId);
+        // まだ切断中なら実際に除外
+        if (room.players.has(socketId) && !room.players.get(socketId)!.connected) {
+          this.removePlayer(socketId);
+          onGraceExpired(room, player);
+        }
+      }, RECONNECT_GRACE_MS);
+
+      room.disconnectTimers.set(socketId, timer);
+
+      return { room, player };
+    }
+
+    return null;
+  }
+
+  /** プレイヤーをルームから完全除外 */
+  removePlayer(socketId: string): { room: Room; leftPlayer: ServerPlayer } | null {
     for (const [code, room] of this.rooms) {
       const player = room.players.get(socketId);
       if (!player) continue;
 
+      // 猶予タイマーをクリア
+      const timer = room.disconnectTimers.get(socketId);
+      if (timer) {
+        clearTimeout(timer);
+        room.disconnectTimers.delete(socketId);
+      }
+
       room.players.delete(socketId);
       room.lastActivity = Date.now();
 
-      // ルームが空になったら削除
-      if (room.players.size === 0) {
+      // ルームが空（全員接続済みのプレイヤーがいない）かチェック
+      const connectedCount = Array.from(room.players.values()).filter(p => p.connected).length;
+      if (room.players.size === 0 || (connectedCount === 0 && room.disconnectTimers.size === 0)) {
+        // 全タイマーをクリア
+        for (const t of room.disconnectTimers.values()) clearTimeout(t);
+        room.disconnectTimers.clear();
         if (room.countdownTimer) {
           clearInterval(room.countdownTimer);
           room.countdownTimer = null;
@@ -195,9 +254,10 @@ export class RoomManager {
         return { room, leftPlayer: player };
       }
 
-      // ホストが抜けた場合は次のプレイヤーをホストに昇格
+      // ホストが抜けた場合は接続中プレイヤーをホストに昇格
       if (room.hostId === socketId) {
-        const nextHost = room.players.values().next().value!;
+        const nextHost = Array.from(room.players.values()).find(p => p.connected)
+          || room.players.values().next().value!;
         nextHost.isHost = true;
         room.hostId = nextHost.socketId;
       }
@@ -206,6 +266,58 @@ export class RoomManager {
     }
 
     return null;
+  }
+
+  /** 再接続: トークンでプレイヤーを検索し、ソケットを紐付け直す */
+  rejoinRoom(
+    socket: TypedSocket,
+    code: string,
+    token: string
+  ): { ok: boolean; room?: Room; error?: string } {
+    const room = this.rooms.get(code.toUpperCase());
+    if (!room) {
+      return { ok: false, error: 'ルームが見つかりません' };
+    }
+
+    // トークンで切断中のプレイヤーを検索
+    let targetPlayer: ServerPlayer | null = null;
+    let oldSocketId: string | null = null;
+
+    for (const [sid, player] of room.players) {
+      if (player.reconnectToken === token) {
+        targetPlayer = player;
+        oldSocketId = sid;
+        break;
+      }
+    }
+
+    if (!targetPlayer || !oldSocketId) {
+      return { ok: false, error: '再接続情報が見つかりません' };
+    }
+
+    // 猶予タイマーをキャンセル
+    const timer = room.disconnectTimers.get(oldSocketId);
+    if (timer) {
+      clearTimeout(timer);
+      room.disconnectTimers.delete(oldSocketId);
+    }
+
+    // ソケットIDを更新
+    room.players.delete(oldSocketId);
+    targetPlayer.id = socket.id;
+    targetPlayer.socketId = socket.id;
+    targetPlayer.connected = true;
+    room.players.set(socket.id, targetPlayer);
+
+    // ホストIDも更新
+    if (room.hostId === oldSocketId) {
+      room.hostId = socket.id;
+    }
+
+    room.lastActivity = Date.now();
+    socket.join(room.code);
+
+    return { ok: true, room };
   }
 
   /** ルームを取得 */
@@ -302,6 +414,11 @@ export class RoomManager {
     room.customSymbols.clear();
     room.lastActivity = Date.now();
     return true;
+  }
+
+  /** ランダムな再接続トークンを生成 */
+  private generateToken(): string {
+    return crypto.randomBytes(16).toString('hex');
   }
 
   /** ランダムなルームコードを生成 */

--- a/shared/src/constants.ts
+++ b/shared/src/constants.ts
@@ -55,6 +55,9 @@ export function getMinCards(mode: string, playerCount: number): number {
 /** ルームの自動削除時間 (ms) - 30分 */
 export const ROOM_TIMEOUT = 30 * 60 * 1000;
 
+/** 再接続猶予時間 (ms) - 30秒 */
+export const RECONNECT_GRACE_MS = 30 * 1000;
+
 /** カスタムシンボル: 最大データURLサイズ (バイト) - 約200KB */
 export const MAX_CUSTOM_SYMBOL_SIZE = 200 * 1024;
 

--- a/shared/src/types.ts
+++ b/shared/src/types.ts
@@ -86,8 +86,9 @@ export interface ServerToClientEvents {
 }
 
 export interface ClientToServerEvents {
-  'room:create': (playerName: string, callback: (response: { ok: boolean; code?: string; error?: string }) => void) => void;
-  'room:join': (code: string, playerName: string, callback: (response: { ok: boolean; error?: string }) => void) => void;
+  'room:create': (playerName: string, callback: (response: { ok: boolean; code?: string; token?: string; error?: string }) => void) => void;
+  'room:join': (code: string, playerName: string, callback: (response: { ok: boolean; token?: string; error?: string }) => void) => void;
+  'room:rejoin': (code: string, token: string, callback: (response: { ok: boolean; error?: string }) => void) => void;
   'room:settings': (settings: GameSettings) => void;
   'room:uploadSymbol': (symbolId: number, dataUrl: string, callback: (response: { ok: boolean; error?: string }) => void) => void;
   'room:deleteSymbol': (symbolId: number) => void;


### PR DESCRIPTION
## Summary
- 切断後30秒間のグレース期間中に自動再接続可能
- トークンベースのセッション管理（localStorage保存）
- 切断中オーバーレイ表示＋Home画面での復帰ボタン
- ゲーム中の切断でも手札・スコア・ホスト権限を維持

## Test plan
- [ ] ブラウザリロードで同じルームに自動復帰できることを確認
- [ ] ゲーム中のリロードで手札・スコアが維持されることを確認
- [ ] 30秒を過ぎると復帰できず従来通り除外されることを確認
- [ ] ホームに戻る→「ルームに戻る」ボタンで復帰できることを確認
- [ ] 他プレイヤーに「切断中」表示が出ることを確認
- [ ] 全94テストがパスすることを確認

Closes #15

🤖 Generated with [Claude Code](https://claude.com/claude-code)